### PR TITLE
Enable celery for changing collection datatypes, exporting

### DIFF
--- a/vars/galaxy_vars.yml
+++ b/vars/galaxy_vars.yml
@@ -113,6 +113,10 @@ galaxy_configuration:
     tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
     dependency_resolvers_config_file: "{{ dependency_resolvers_config_file }}"
     container_resolvers_config_file: "{{ container_resolvers_config_file }}"
+    expose_dataset_path: true
+    expose_potentially_sensitive_job_metrics: true
+    expose_user_name: true
+    # Celery support
     enable_celery_tasks: true
     amqp_internal_connection: "sqlalchemy+postgresql:///galaxy?host=/var/run/postgresql"
     celery_conf:

--- a/vars/galaxy_vars.yml
+++ b/vars/galaxy_vars.yml
@@ -113,6 +113,14 @@ galaxy_configuration:
     tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
     dependency_resolvers_config_file: "{{ dependency_resolvers_config_file }}"
     container_resolvers_config_file: "{{ container_resolvers_config_file }}"
+    enable_celery_tasks: true
+    amqp_internal_connection: "sqlalchemy+postgresql:///galaxy?host=/var/run/postgresql"
+    celery_conf:
+      broker_url: null
+      result_backend: "db+postgresql:///galaxy?host=/var/run/postgresql"
+      task_routes:
+        galaxy.fetch_data: galaxy.external
+        galaxy.set_job_metadata: galaxy.external
 
   gravity:
     galaxy_root: "{{ galaxy_server_dir }}"


### PR DESCRIPTION
- celery tasks are very useful and can be accomplished just by changing to use the database for those tasks, I believe
- added some 'expose' variables to expose useful information to end users of the service, not sure if you want those? Could be reverted
- I didn't see an `id_secret` set, it would be... good to set that. It could be set with e.g. `id_secret: {{ lookup('community.general.random_string', length=24) }}`